### PR TITLE
Add official provider support and modernize popup

### DIFF
--- a/prepareBuild.js
+++ b/prepareBuild.js
@@ -1,19 +1,43 @@
-const fs = require('fs');
-const readline = require('readline');
-const path = require('path');
-
-const rl = readline.createInterface({
-  input: process.stdin,
-  output: process.stdout
-});
+const fs = require("fs");
+const readline = require("readline");
+const path = require("path");
 
 const questions = [
   "Is it a major update? (y/n) ",
   "Did you add a new feature? (y/n) ",
-  "Is it a bug fix/minor update? (y/n) "
+  "Is it a bug fix/minor update? (y/n) ",
 ];
 
+const envAnswerKeys = [
+  "PREPARE_BUILD_MAJOR",
+  "PREPARE_BUILD_FEATURE",
+  "PREPARE_BUILD_BUGFIX",
+];
+
+const rl = readline.createInterface({
+  input: process.stdin,
+  output: process.stdout,
+});
+
 let answers = [];
+
+function normalizeAnswer(value, fallback = "n") {
+  if (!value) {
+    return fallback;
+  }
+
+  const normalized = String(value).trim().toLowerCase();
+  return normalized.startsWith("y") ? "y" : "n";
+}
+
+function shouldAutoRun() {
+  return (
+    process.env.CI === "true" ||
+    process.argv.includes("--non-interactive") ||
+    process.env.PREPARE_BUILD_AUTOMATIC === "true" ||
+    !process.stdin.isTTY
+  );
+}
 
 function askQuestion(index) {
   if (index === questions.length) {
@@ -21,33 +45,43 @@ function askQuestion(index) {
     return;
   }
 
-  rl.question(questions[index], function(answer) {
-    answers.push(answer);
+  rl.question(questions[index], (answer) => {
+    answers.push(normalizeAnswer(answer));
     askQuestion(index + 1);
   });
 }
 
 function updateManifest() {
-  const manifestPath = path.join(__dirname, '/src/manifest.json');
+  const manifestPath = path.join(__dirname, "/src/manifest.json");
   const manifest = require(manifestPath);
-  let version = manifest.version.split('.');
+  const version = manifest.version.split(".");
 
-  if (answers[0] === 'y') version[0] = Number(version[0]) + 1;
-  if (answers[1] === 'y') version[1] = Number(version[1]) + 1;
-  if (answers[2] === 'y') version[2] = Number(version[2]) + 1;
+  if (answers[0] === "y") version[0] = Number(version[0]) + 1;
+  if (answers[1] === "y") version[1] = Number(version[1]) + 1;
+  if (answers[2] === "y") version[2] = Number(version[2]) + 1;
 
-  manifest.version = version.join('.');
+  manifest.version = version.join(".");
 
-  fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), 'utf8', function(err) {
+  fs.writeFile(manifestPath, JSON.stringify(manifest, null, 2), "utf8", (err) => {
     if (err) {
-      console.log('An error occurred while writing the manifest file.');
+      console.log("An error occurred while writing the manifest file.");
       console.error(err);
       process.exit(1);
     } else {
-      console.log('Manifest file has been updated.');
+      console.log("Manifest file has been updated.");
       rl.close();
     }
   });
 }
 
-askQuestion(0);
+function run() {
+  if (shouldAutoRun()) {
+    answers = envAnswerKeys.map((key) => normalizeAnswer(process.env[key]));
+    updateManifest();
+    return;
+  }
+
+  askQuestion(0);
+}
+
+run();

--- a/src/contentScript.js
+++ b/src/contentScript.js
@@ -1,218 +1,745 @@
-//ofc fetch the GPT Response!
+const DEFAULT_SETTINGS = {
+  tune: "balance",
+  gptModel: "openai-gpt-4o-mini",
+  youtubeSummary: true,
+  aiCommand: true,
+  googleSearch: true,
+  initialPrompt: `You are ChatGPT, a large language model trained by OpenAI.
+Carefully heed the user's instructions.
+Respond using Markdown and keep answers concise but complete.
+When creating content for the user, answer directly without filler phrases.
+After answering, provide follow-up ideas prefixed with "GPT-SUGGEST:" in JSON format.`,
+  openaiApiKey: "",
+  geminiApiKey: "",
+  anthropicApiKey: "",
+  deepseekApiKey: "",
+};
+
+const MODEL_CONFIGS = {
+  "openai-gpt-4o-mini": {
+    id: "openai-gpt-4o-mini",
+    name: "OpenAI GPT-4o mini",
+    provider: "openai",
+    model: "gpt-4o-mini",
+    endpoint: "https://api.openai.com/v1/chat/completions",
+    supportsStreaming: true,
+    capabilities: ["text"],
+  },
+  "openai-gpt-4o": {
+    id: "openai-gpt-4o",
+    name: "OpenAI GPT-4o",
+    provider: "openai",
+    model: "gpt-4o",
+    endpoint: "https://api.openai.com/v1/chat/completions",
+    supportsStreaming: true,
+    capabilities: ["text"],
+  },
+  "gemini-1.5-flash": {
+    id: "gemini-1.5-flash",
+    name: "Gemini 1.5 Flash",
+    provider: "gemini",
+    model: "gemini-1.5-flash",
+    supportsStreaming: false,
+    capabilities: ["text", "vision"],
+  },
+  "gemini-2.0-flash": {
+    id: "gemini-2.0-flash",
+    name: "Gemini 2.0 Flash",
+    provider: "gemini",
+    model: "gemini-2.0-flash-exp",
+    supportsStreaming: false,
+    capabilities: ["text"],
+  },
+  "anthropic-claude-3-5-sonnet": {
+    id: "anthropic-claude-3-5-sonnet",
+    name: "Claude 3.5 Sonnet",
+    provider: "anthropic",
+    model: "claude-3-5-sonnet-20240620",
+    endpoint: "https://api.anthropic.com/v1/messages",
+    supportsStreaming: false,
+    capabilities: ["text"],
+  },
+  "deepseek-chat": {
+    id: "deepseek-chat",
+    name: "DeepSeek Chat",
+    provider: "deepseek",
+    model: "deepseek-chat",
+    endpoint: "https://api.deepseek.com/chat/completions",
+    supportsStreaming: true,
+    capabilities: ["text"],
+  },
+  "deepseek-reasoner": {
+    id: "deepseek-reasoner",
+    name: "DeepSeek Reasoner",
+    provider: "deepseek",
+    model: "deepseek-reasoner",
+    endpoint: "https://api.deepseek.com/chat/completions",
+    supportsStreaming: true,
+    capabilities: ["text"],
+  },
+};
+
+const TUNING_PRESETS = {
+  creative: { temperature: 0.9, topP: 0.9 },
+  balance: { temperature: 0.7, topP: 0.8 },
+  precise: { temperature: 0.4, topP: 0.65 },
+};
+
+const FOLLOW_UP_INSTRUCTION = `Provide one or more follow-up questions the user might ask next.
+Format the suggestions exactly as a JSON array like this:
+[{"suggestion":"1","text":"Question text"}].
+Keep each suggestion concise.`;
+
+let cachedSettings = { ...DEFAULT_SETTINGS };
 let ttsReady = false;
 
-async function fetchFreeGPTResponse(prompt, onChunkReceived) {
+chrome.storage.sync.get(DEFAULT_SETTINGS, (items) => {
+  cachedSettings = { ...cachedSettings, ...items };
+});
 
-  document.querySelector(".popup-suggestion-wrapper").innerHTML = "";
-  ttsReady = false;
-  let url = "";
-  let Authorization = "";
-  let model = "";
-  model = "gpt-3.5-turbo"
-  /*wait chrome.storage.sync.get("gptModel", function (items) {
-    if (items.gptModel) {
-      model = items.gptModel;
+chrome.storage.onChanged.addListener((changes, area) => {
+  if (area !== "sync") {
+    return;
+  }
+
+  Object.entries(changes).forEach(([key, { newValue }]) => {
+    if (typeof newValue === "undefined") {
+      cachedSettings[key] = DEFAULT_SETTINGS[key];
     } else {
-      model = "gpt-3.5-turbo";
+      cachedSettings[key] = newValue;
     }
-  });*/
-  console.log("Currently using model : " + model);
-  model == "gpt-3.5-turbo"
-    ? (Authorization = "Bearer MyDiscord")
-    : (Authorization = "Bearer MyDiscord");
-  model == "gpt-3.5-turbo"
-    ? (url = "https://free.churchless.tech/v1/chat/completions")
-    : (url = "https://free.churchless.tech/v1/chat/completions");
+  });
+});
+
+function getModelConfig(modelId) {
+  return MODEL_CONFIGS[modelId] || MODEL_CONFIGS[DEFAULT_SETTINGS.gptModel];
+}
+
+function getTuningPreset(tune) {
+  return TUNING_PRESETS[tune] || TUNING_PRESETS.balance;
+}
+
+function getApiKeyForProvider(provider) {
+  switch (provider) {
+    case "openai":
+      return (cachedSettings.openaiApiKey || "").trim();
+    case "gemini":
+      return (cachedSettings.geminiApiKey || "").trim();
+    case "anthropic":
+      return (cachedSettings.anthropicApiKey || "").trim();
+    case "deepseek":
+      return (cachedSettings.deepseekApiKey || "").trim();
+    default:
+      return "";
+  }
+}
+
+function parseSuggestionsFromText(rawText) {
+  if (!rawText) {
+    return [];
+  }
+
+  const withoutPrefix = rawText.replace(/^GPT-SUGGEST:\s*/i, "").trim();
+  const unwrapped = withoutPrefix
+    .replace(/^```(?:json)?/i, "")
+    .replace(/```$/, "")
+    .trim();
+
+  const jsonMatch = unwrapped.match(/\{.*\}|\[.*\]/s);
+  const candidate = jsonMatch ? jsonMatch[0] : unwrapped;
+
+  try {
+    const parsed = JSON.parse(candidate);
+    if (Array.isArray(parsed)) {
+      return parsed
+        .map((item) => {
+          if (typeof item === "string") {
+            return { suggestion: item, text: item };
+          }
+          return {
+            suggestion: item.suggestion || item.id || item.text || "",
+            text: item.text || item.suggestion || "",
+          };
+        })
+        .filter((item) => item.text);
+    }
+
+    if (parsed && typeof parsed === "object") {
+      const fromKey = parsed["GPT-SUGGEST"] || parsed.suggestions || parsed.items;
+      if (Array.isArray(fromKey)) {
+        return fromKey
+          .map((text) => {
+            if (typeof text === "string") {
+              return { suggestion: text, text };
+            }
+            return {
+              suggestion: text?.suggestion || text?.text || "",
+              text: text?.text || text?.suggestion || "",
+            };
+          })
+          .filter((item) => item.text);
+      }
+    }
+  } catch (error) {
+    console.warn("Unable to parse suggestion payload", error, rawText);
+  }
+
+  return [];
+}
+
+async function maybeAugmentPromptWithInternet(prompt) {
+  try {
+    const internetMode = localStorage.getItem("gptinternet");
+    if (internetMode !== "true") {
+      return prompt;
+    }
+
+    const searchUrl = `https://gpt-otg-websearch-api.vercel.app/search?query=${encodeURIComponent(prompt)}`;
+    const response = await fetch(searchUrl, {
+      credentials: "omit",
+      mode: "cors",
+    });
+    if (!response.ok) {
+      return prompt;
+    }
+    const internetPrompt = await response.text();
+    return internetPrompt || prompt;
+  } catch (error) {
+    console.warn("Failed to augment prompt with internet results", error);
+    return prompt;
+  }
+}
+
+function buildSuggestionButtons(suggestions, onSelect) {
+  const wrapper = document.querySelector(".popup-suggestion-wrapper");
+  if (!wrapper) {
+    return;
+  }
+  wrapper.innerHTML = "";
+  if (!suggestions?.length) {
+    wrapper.classList.remove("has-suggestions");
+    return;
+  }
+  wrapper.classList.add("has-suggestions");
+  suggestions.forEach((suggestion) => {
+    const button = document.createElement("button");
+    button.type = "button";
+    button.classList.add("suggestion-button");
+    button.textContent = suggestion.text;
+    button.addEventListener("click", () => onSelect(suggestion.text));
+    wrapper.appendChild(button);
+  });
+}
+
+function extractGeminiText(payload) {
+  const parts = payload?.candidates?.[0]?.content?.parts || [];
+  return parts
+    .map((part) => part.text || "")
+    .join("")
+    .trim();
+}
+
+async function requestGeminiContent({ model, apiKey, systemPrompt, tuning, parts }) {
+  if (!apiKey) {
+    throw new Error("Gemini API key is missing. Add it from the options page.");
+  }
+
+  const endpoint = `https://generativelanguage.googleapis.com/v1beta/models/${model}:generateContent?key=${encodeURIComponent(apiKey)}`;
+
+  const body = {
+    contents: [
+      {
+        role: "user",
+        parts,
+      },
+    ],
+    generationConfig: {
+      temperature: tuning.temperature,
+      topP: tuning.topP,
+    },
+  };
+
+  if (systemPrompt) {
+    body.systemInstruction = {
+      role: "system",
+      parts: [{ text: systemPrompt }],
+    };
+  }
+
+  const response = await fetch(endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify(body),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Gemini request failed: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  return extractGeminiText(data);
+}
+
+function guessMimeTypeFromUrl(url) {
+  try {
+    const { pathname } = new URL(url);
+    const extension = pathname.split(".").pop()?.toLowerCase();
+    switch (extension) {
+      case "png":
+        return "image/png";
+      case "gif":
+        return "image/gif";
+      case "webp":
+        return "image/webp";
+      case "svg":
+        return "image/svg+xml";
+      case "bmp":
+        return "image/bmp";
+      case "ico":
+        return "image/x-icon";
+      default:
+        return "image/jpeg";
+    }
+  } catch (error) {
+    return "image/jpeg";
+  }
+}
+
+async function fetchImageInlineParts(imageUrl) {
+  const response = await fetch(imageUrl, {
+    mode: "cors",
+    credentials: "omit",
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text().catch(() => "");
+    throw new Error(`Image download failed: ${response.status} ${errorText}`.trim());
+  }
+
+  const mimeType = response.headers.get("Content-Type") || guessMimeTypeFromUrl(imageUrl);
+  const buffer = await response.arrayBuffer();
+  const bytes = new Uint8Array(buffer);
+  const chunkSize = 0x8000;
+  let binary = "";
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    binary += String.fromCharCode(...bytes.subarray(i, i + chunkSize));
+  }
+  const base64 = btoa(binary);
+
+  return [
+    {
+      inlineData: {
+        data: base64,
+        mimeType,
+      },
+    },
+  ];
+}
+
+async function callOpenAiCompatible({
+  prompt,
+  systemPrompt,
+  tuning,
+  onChunkReceived,
+  config,
+  apiKey,
+}) {
+  if (!apiKey) {
+    throw new Error("Add your API key for the selected provider in the options page.");
+  }
 
   const headers = {
     "Content-Type": "application/json",
     Accept: "*/*",
-    "Referrer-Policy": "strict-origin-when-cross-origin",
-    Authorization: Authorization,
+    Authorization: `Bearer ${apiKey}`,
   };
-  
-/*
-  let initialPrompt = "";
- try {
-    await chrome.storage.sync.get("initialPrompt", function (items) {
-      initialPrompt = data.initialPrompt;
-    });
-  } catch (error) {
-    initialPrompt ="You are ChatGPT, a large language model trained by OpenAI. Your role is to provide succinct, relevant responses to user queries. At the end of each interaction, offer one or more suggestions for future questions the user might ask. Each suggestion should start with the phrase 'Suggestion: ', followed by the number and the question text.For instance, if a user asks 'Who is Spiderman?', you might suggest: 'Suggestion 1: How strong is Spiderman?' and 'Suggestion 2: Who are some of Spiderman's most formidable enemies?'.Users may summon you anywhere online by typing '/ai' or '/typeai'. If a user requests you to create content such as posts, captions, emails, or letters, provide only the required text without any leading phrases (e.g., 'Sure, here is...') or concluding remarks. Your response should be focused solely on fulfilling the user's request. Please respond using markdown.";
-  }*/
 
-  //check if initial prompt is empty, if not use the "You are ChatGPT, a large language model trained by OpenAI.\nCarefully heed the user's instructions. \nDon't give Respond too Long or too short,make it summary. \nRespond using Markdown. \nYou are a part of chrome extension now that was made by myanpetra99, that You could be used anywhere around the web just type like '/ai' or '/typeai' to spawn you. \nWhen user tell you to type something or tell to someone or create a post or caption or status or write an email or write a letter about something, just give the straight answer without any extra sentences before the answer like `Sure, here's the...` or like `Sure, I'd be happy to help you write a..` and it can be the other, and don't add anything after the answer, just give straight pure answer about what the user just asked.",
-  //if empty use the initial prompt from the user
-
-  let internetMode = localStorage.getItem("gptinternet");
-
-  let interneturl = `https://gpt-otg-websearch-api.vercel.app/search?query=${prompt}`
-  if (internetMode === "true" ) {
-    const internetPrompt =  await fetch(interneturl, {
-      credentials: "omit",
-      mode: "cors",
-    });
-
-    prompt = await internetPrompt.text();
-  }
-
-  const messages = [
+  const baseMessages = [
+    { role: "system", content: systemPrompt },
     { role: "user", content: prompt },
-    { role: "assistant", content: "" },
-    {
-      role: "system",
-      content: `You are ChatGPT, a large language model trained by OpenAI. 
-      Your role is to provide succinct, relevant responses to user queries. 
-      Users may summon you anywhere online by typing '/ai' or '/typeai'. If a user requests you to create content such as posts, captions, emails, or letters, 
-      provide only the required text without any leading phrases (e.g., 'Sure, here is...') or concluding remarks. 
-      Your response should be focused solely on fulfilling the user's request.`
-    },
   ];
 
-  let tuned = {};
-
-  await chrome.storage.sync.get("tune", function (items) {
-    if (items.tune) {
-      if (items.tune == "balance") {
-        tuned.temperature = 0.5;
-        tuned.topP = 0.5;
-      } else if (items.tune == "creative") {
-        tuned.temperature = 0.1;
-        tuned.topP = 0.1;
-      } else if (items.tune == "precise") {
-        tuned.temperature = 1;
-        tuned.topP = 1;
-      }
-    } else {
-      tuned.temperature = 1;
-      tuned.topP = 1;
-    }
-  });
-
-  stream = true
-  
-  let payload = {
-    messages: messages,
-    model: model,
-    temperature: 1,
+  const payload = {
+    model: config.model,
+    messages: baseMessages,
+    temperature: tuning.temperature,
+    top_p: tuning.topP,
     presence_penalty: 0,
-    top_p: 1,
     frequency_penalty: 0,
-    stream: stream,
+    stream: config.supportsStreaming,
   };
 
-  const response = await fetch(url, {
+  const response = await fetch(config.endpoint, {
     method: "POST",
-    headers: headers,
+    headers,
     body: JSON.stringify(payload),
     credentials: "omit",
     mode: "cors",
   });
 
-  if ( stream ) {
-    if (response.ok) {
-      console.log("GPT Model:" + model);
-      const reader = response.body.getReader();
-      const decoder = new TextDecoder();
-      let buffer = "";
-  
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Model request failed: ${response.status} ${errorText}`);
+  }
+
+  let aggregatedText = "";
+
+  if (config.supportsStreaming && response.body) {
+    const reader = response.body.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+
+      buffer += decoder.decode(value, { stream: true });
+
       while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
+        const nextNewline = buffer.indexOf("\n");
+        if (nextNewline === -1) {
           break;
         }
-        buffer += decoder.decode(value, { stream: true });
-  
-        while (true) {
-          const nextNewline = buffer.indexOf("\n");
-          if (nextNewline === -1) {
-            break;
+
+        const line = buffer.slice(0, nextNewline);
+        buffer = buffer.slice(nextNewline + 1);
+
+        if (line.startsWith("data: ")) {
+          const jsonData = line.substring(6).trim();
+          if (!jsonData || jsonData === "[DONE]") {
+            continue;
           }
-  
-          const line = buffer.slice(0, nextNewline);
-          buffer = buffer.slice(nextNewline + 1);
-  
-          if (line.startsWith("data: ")) {
-            const jsonData = line.substring(6);
-            if (jsonData.trim() !== "[DONE]") {
-              try {
-                const chunkJson = JSON.parse(jsonData);
-                let chunkContent = chunkJson.choices[0].delta.content;
-                if (typeof chunkContent === "undefined") {
-                  chunkContent = ""; // Set to empty string if content is undefined
-                }
-                onChunkReceived(chunkContent);
-              } catch (e) {
-                console.error("Invalid JSON:", e);
-              }
+
+          try {
+            const chunkJson = JSON.parse(jsonData);
+            const chunkContent = chunkJson?.choices?.[0]?.delta?.content;
+            if (typeof chunkContent === "string") {
+              aggregatedText += chunkContent;
+              onChunkReceived(chunkContent);
             }
+          } catch (error) {
+            console.warn("Failed to parse streamed chunk", error, jsonData);
           }
         }
       }
-    } else {
-      onChunkReceived("Sorry, something went wrong");
     }
   } else {
-    if (response.ok) {
-      console.log("GPT Model:" + model);
-      const data = await response.json();
-      let chunkContent = data.choices[0].message.content;
-      if (typeof chunkContent === "undefined") {
-        chunkContent = ""; // Set to empty string if content is undefined
-      }
-      onChunkReceived(chunkContent);
-    } else {
-      onChunkReceived("Sorry, something went wrong");
-    }
+    const data = await response.json();
+    const chunkContent = data?.choices?.[0]?.message?.content || "";
+    aggregatedText += chunkContent;
+    onChunkReceived(chunkContent);
   }
 
-  let gptResult = document.querySelector("#popup-gpt-result").textContent;
-  payload.stream = false;
-  payload.messages[1].content = gptResult;
-  payload.messages[2].content = `provide one or more suggestions based on the user prompt and your response.
-  These suggestions should follow this specific format: [{"suggestion": "1", "text": "Your question here"}, {"suggestion": "2", "text": "Your second question here"}]. 
-  For instance, if a user asks 'Who is Spiderman?', you should end your response EXACTLY LIKE THIS: "GPT-SUGGEST: [{"suggestion": "1", text: "How strong is Spiderman?"}, {"suggestion": "2", "text": "Who are some of Spiderman's most formidable enemies?"}]". 
-  No leading or trailing phrases should be used around these suggestions; they should follow immediately after the answer to the initial query.`;
-  
-  const responseSuggest = await fetch(url, {
+  return {
+    text: aggregatedText,
+    context: {
+      type: "openaiCompatible",
+      config,
+      headers,
+      baseMessages,
+      tuning,
+    },
+  };
+}
+
+async function callGemini({ prompt, systemPrompt, tuning, onChunkReceived, config, imageParts = [] }) {
+  const apiKey = (cachedSettings.geminiApiKey || "").trim();
+  const parts = [...imageParts, { text: prompt }];
+  const text = await requestGeminiContent({
+    model: config.model,
+    apiKey,
+    systemPrompt,
+    tuning,
+    parts,
+  });
+
+  if (text) {
+    onChunkReceived(text);
+  }
+
+  return {
+    text,
+    context: {
+      type: "gemini",
+      config,
+      apiKey,
+      tuning,
+      systemPrompt,
+    },
+  };
+}
+
+async function callAnthropic({ prompt, systemPrompt, tuning, onChunkReceived, config }) {
+  const apiKey = (cachedSettings.anthropicApiKey || "").trim();
+  if (!apiKey) {
+    throw new Error("Add your Anthropic API key from the options page to use Claude models.");
+  }
+
+  const payload = {
+    model: config.model,
+    system: systemPrompt,
+    messages: [
+      {
+        role: "user",
+        content: [{ type: "text", text: prompt }],
+      },
+    ],
+    max_tokens: 1024,
+    temperature: tuning.temperature,
+  };
+
+  const response = await fetch(config.endpoint, {
     method: "POST",
-    headers: headers,
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Claude request failed: ${response.status} ${errorText}`);
+  }
+
+  const data = await response.json();
+  const text = data?.content?.map((part) => part.text || "").join("") || "";
+  if (text) {
+    onChunkReceived(text);
+  }
+
+  return {
+    text,
+    context: {
+      type: "anthropic",
+      config,
+      systemPrompt,
+      tuning,
+      apiKey,
+    },
+  };
+}
+
+async function generateOpenAiSuggestions({ prompt, responseText, context }) {
+  const { config, headers, baseMessages, tuning } = context;
+  const messages = [
+    ...baseMessages,
+    { role: "assistant", content: responseText },
+    { role: "system", content: FOLLOW_UP_INSTRUCTION },
+  ];
+
+  const payload = {
+    model: config.model,
+    messages,
+    temperature: Math.min(tuning.temperature + 0.1, 1),
+    top_p: Math.min(tuning.topP + 0.1, 1),
+    presence_penalty: 0,
+    frequency_penalty: 0,
+    stream: false,
+  };
+
+  const response = await fetch(config.endpoint, {
+    method: "POST",
+    headers,
     body: JSON.stringify(payload),
     credentials: "omit",
     mode: "cors",
   });
 
-//...
-if (responseSuggest.ok) {
-  console.log("GPT Model:" + model);
-  const data = await responseSuggest.json();
-  let chunkContent = data.choices[0].message.content;
-  if (typeof chunkContent === "undefined") {
-    chunkContent = "";
-  }
-  console.log(chunkContent);
-
-  const suggestIndex = chunkContent.indexOf("GPT-SUGGEST:");
-  if (suggestIndex !== -1) {
-      chunkContent = chunkContent.slice(suggestIndex + "GPT-SUGGEST:".length);
+  if (!response.ok) {
+    throw new Error(`Suggestion request failed: ${response.status}`);
   }
 
-  console.log(chunkContent);
-const suggestions = JSON.parse(chunkContent);
-suggestions.forEach((suggestion) => {
-  const button = document.createElement("button");
-  button.innerHTML = suggestion.text;
-  button.classList.add('suggestion-button'); // Add any CSS classes if you want
-  button.addEventListener("click", () => {
-    document.querySelector("#popup-gpt-result").textContent = "";
-    fetchFreeGPTResponse(suggestion.text, onChunkReceived);
+  const data = await response.json();
+  const text = data?.choices?.[0]?.message?.content || "";
+  return parseSuggestionsFromText(text);
+}
+
+async function generateGeminiSuggestions({ prompt, responseText, context }) {
+  const { config, apiKey, systemPrompt, tuning } = context;
+  const instruction = `The user asked: ${prompt}.\nYou responded: ${responseText}.\n${FOLLOW_UP_INSTRUCTION}`;
+
+  const text = await requestGeminiContent({
+    model: config.model,
+    apiKey,
+    systemPrompt,
+    tuning,
+    parts: [{ text: instruction }],
   });
 
-  document.querySelector(".popup-suggestion-wrapper").appendChild(button);
-});
-
-} 
+  return parseSuggestionsFromText(text);
 }
+
+async function generateAnthropicSuggestions({ prompt, responseText, context }) {
+  const { config, apiKey, systemPrompt, tuning } = context;
+  const payload = {
+    model: config.model,
+    system: `${systemPrompt}\n\n${FOLLOW_UP_INSTRUCTION}`.trim(),
+    messages: [
+      {
+        role: "user",
+        content: [
+          {
+            type: "text",
+            text: `User prompt: ${prompt}\nAssistant reply: ${responseText}`,
+          },
+        ],
+      },
+    ],
+    max_tokens: 512,
+    temperature: Math.min(tuning.temperature + 0.15, 1),
+  };
+
+  const response = await fetch(config.endpoint, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-api-key": apiKey,
+      "anthropic-version": "2023-06-01",
+    },
+    body: JSON.stringify(payload),
+  });
+
+  if (!response.ok) {
+    throw new Error(`Suggestion request failed: ${response.status}`);
+  }
+
+  const data = await response.json();
+  const text = data?.content?.map((part) => part.text || "").join("") || "";
+  return parseSuggestionsFromText(text);
+}
+
+async function renderSuggestions({ prompt, responseText, result }) {
+  try {
+    if (!responseText) {
+      return;
+    }
+
+    let suggestions = [];
+    if (result.context?.type === "openaiCompatible") {
+      suggestions = await generateOpenAiSuggestions({
+        prompt,
+        responseText,
+        context: result.context,
+      });
+    } else if (result.context?.type === "gemini") {
+      suggestions = await generateGeminiSuggestions({
+        prompt,
+        responseText,
+        context: result.context,
+      });
+    } else if (result.context?.type === "anthropic") {
+      suggestions = await generateAnthropicSuggestions({
+        prompt,
+        responseText,
+        context: result.context,
+      });
+    }
+
+    if (!suggestions.length) {
+      return;
+    }
+
+    buildSuggestionButtons(suggestions, (followUpPrompt) => {
+      const resultElement = document.querySelector("#popup-gpt-result");
+      if (resultElement) {
+        resultElement.textContent = "";
+      }
+      fetchFreeGPTResponse(followUpPrompt, (chunk) => {
+        if (resultElement) {
+          resultElement.textContent += chunk;
+        }
+      });
+    });
+  } catch (error) {
+    console.warn("Unable to render suggestions", error);
+  }
+}
+
+async function fetchFreeGPTResponse(prompt, onChunkReceived, options = {}) {
+  const suggestionWrapper = document.querySelector(".popup-suggestion-wrapper");
+  if (suggestionWrapper) {
+    suggestionWrapper.innerHTML = "";
+    suggestionWrapper.classList.remove("has-suggestions");
+  }
+
+  ttsReady = false;
+
+  const settings = { ...DEFAULT_SETTINGS, ...cachedSettings };
+  const config = getModelConfig(settings.gptModel);
+  const systemPrompt = (settings.initialPrompt || DEFAULT_SETTINGS.initialPrompt).trim();
+  const tuning = getTuningPreset(settings.tune);
+
+  let preparedPrompt = prompt;
+  if (!options.imageParts?.length) {
+    preparedPrompt = await maybeAugmentPromptWithInternet(prompt);
+  }
+
+  if (options.imageParts?.length && !config.capabilities.includes("vision")) {
+    onChunkReceived(
+      "The selected model cannot analyze images. Please choose a vision-capable model in the options page."
+    );
+    return "";
+  }
+
+  try {
+    let result;
+    if (config.provider === "openai" || config.provider === "deepseek") {
+      const apiKey = getApiKeyForProvider(config.provider);
+      result = await callOpenAiCompatible({
+        prompt: preparedPrompt,
+        systemPrompt,
+        tuning,
+        onChunkReceived,
+        config,
+        apiKey,
+      });
+    } else if (config.provider === "gemini") {
+      result = await callGemini({
+        prompt: preparedPrompt,
+        systemPrompt,
+        tuning,
+        onChunkReceived,
+        config,
+        imageParts: options.imageParts,
+      });
+    } else if (config.provider === "anthropic") {
+      result = await callAnthropic({
+        prompt: preparedPrompt,
+        systemPrompt,
+        tuning,
+        onChunkReceived,
+        config,
+      });
+    } else {
+      throw new Error(`Unsupported provider: ${config.provider}`);
+    }
+
+    ttsReady = Boolean(result.text);
+    await renderSuggestions({ prompt: preparedPrompt, responseText: result.text, result });
+    return result.text;
+  } catch (error) {
+    console.error("AI request failed", error);
+    const message = error?.message || "";
+    if (/Gemini API key/.test(message)) {
+      onChunkReceived("Please add your Gemini API key from the options page before using this model.");
+    } else if (/Anthropic API key/.test(message)) {
+      onChunkReceived("Please add your Anthropic API key to chat with Claude.");
+    } else if (/Add your API key/.test(message)) {
+      onChunkReceived("Please add the required API key for this model in the extension options.");
+    } else {
+      onChunkReceived("Sorry, something went wrong");
+    }
+    return "";
+  }
+}
+
 // list dictionary command
 const dictCommand = {
   "/ai": { service: "gpt", mode: "ASK" },
@@ -277,30 +804,43 @@ function createPopup() {
     }
   };
 
-  const closeButton = document.createElement("button");
-  closeButton.innerHTML = "&times;";
-  closeButton.classList.add("popup-close-button");
-  closeButton.onclick = () => hidePopup(popup, input, gptResult);
+  const popupWrapper = document.createElement("div");
+  popupWrapper.classList.add("popup-wrapper");
 
-  const gearButton = document.createElement("button");
-  gearButton.innerHTML = "&#9881;"; // Add gear icon as HTML entity
-  gearButton.classList.add("popup-gear-button"); // Add a CSS class to style the button
-  gearButton.onclick = () => {
-    chrome.runtime.sendMessage({ action: "OpenOptionsPage" });
-  };
+  const header = document.createElement("div");
+  header.classList.add("popup-header");
 
-  // Append the gear button to the popup
+  const titleStack = document.createElement("div");
+  titleStack.classList.add("popup-title");
+  const title = document.createElement("p");
+  title.textContent = "Hello, May I help?";
+  titleStack.appendChild(title);
+
+  const toolbar = document.createElement("div");
+  toolbar.classList.add("popup-toolbar");
+
+  const internetButton = document.createElement("button");
+  internetButton.type = "button";
+  internetButton.innerText = "WWW";
+  internetButton.classList.add("popup-icon-button");
+  internetButton.title = "Toggle web search";
+  internetButton.id = "internet-button";
+  if (localStorage.getItem("gptinternet") === "true") {
+    internetButton.classList.add("enabled");
+  }
+  internetButton.addEventListener("click", () => {
+    ToggleInternetButton();
+  });
 
   const ttsButton = document.createElement("button");
-  ttsButton.innerHTML = "TTS"; // Or any other label/icon you prefer
-  ttsButton.classList.add("popup-tts-button"); // Add a CSS class to style the button
-  popup.appendChild(ttsButton); // Add it next to the gear button
+  ttsButton.type = "button";
+  ttsButton.innerText = "TTS";
+  ttsButton.classList.add("popup-icon-button");
+  ttsButton.title = "Speak the answer";
   ttsButton.onclick = () => {
     if (ttsReady) {
       const gptResult = document.querySelector("#popup-gpt-result");
       const utterance = new SpeechSynthesisUtterance(gptResult.textContent);
-
-      // This function will be called when the list of voices has been populated
       function setVoice() {
         const voice = window.speechSynthesis
           .getVoices()
@@ -308,29 +848,37 @@ function createPopup() {
         if (voice) utterance.voice = voice;
         window.speechSynthesis.speak(utterance);
       }
-
-      // If the voices are already loaded, use the desired voice immediately
       if (window.speechSynthesis.getVoices().length) {
         setVoice();
       } else {
-        // If the voices are not yet loaded, wait for the voiceschanged event before setting the voice
         window.speechSynthesis.onvoiceschanged = setVoice;
       }
     }
   };
 
-  const internetButton = document.createElement("button");
-  internetButton.innerHTML =  "WWW" // Add gear icon as HTML entity
-  internetButton.classList.add("popup-internet-button");
-  internetButton.id = "internet-button";
-
-  internetButton.onclick = () => {
-    ToggleInternetButton();
+  const gearButton = document.createElement("button");
+  gearButton.type = "button";
+  gearButton.innerHTML = "&#9881;";
+  gearButton.classList.add("popup-icon-button");
+  gearButton.title = "Open settings";
+  gearButton.onclick = () => {
+    chrome.runtime.sendMessage({ action: "OpenOptionsPage" });
   };
 
-  popup.appendChild(internetButton);
-  popup.appendChild(gearButton);
-  
+  const closeButton = document.createElement("button");
+  closeButton.type = "button";
+  closeButton.innerHTML = "&times;";
+  closeButton.classList.add("popup-icon-button", "popup-close-button");
+  closeButton.title = "Close";
+  closeButton.onclick = () => hidePopup(popup, input, gptResult);
+
+  toolbar.appendChild(internetButton);
+  toolbar.appendChild(ttsButton);
+  toolbar.appendChild(gearButton);
+  toolbar.appendChild(closeButton);
+
+  header.appendChild(titleStack);
+  header.appendChild(toolbar);
 
   const inputWrapper = document.createElement("div");
   inputWrapper.style.display = "flex";
@@ -350,16 +898,9 @@ function createPopup() {
   inputWrapper.appendChild(input);
 
   const suggestionWrapper = document.createElement("div");
-  suggestionWrapper.style.display = "flex";
-  suggestionWrapper.style.flexDirection = "column";
   suggestionWrapper.classList.add("popup-suggestion-wrapper");
 
-  // Add a wrapper for the popup
-  const popupWrapper = document.createElement("div");
-  popupWrapper.classList.add("popup-wrapper");
-
-  // Move existing elements into the wrapper
-  popupWrapper.appendChild(closeButton);
+  popupWrapper.appendChild(header);
   popupWrapper.appendChild(inputWrapper);
 
   const textareaWrapper = document.createElement("div");
@@ -670,7 +1211,7 @@ function createPopup() {
       console.log(mousePosition.x);
       console.log(mousePosition.y);
 
-      
+
       // Get the selected text from the request
       const selectedText = request.selectionText;
       if (selectedText) {
@@ -692,28 +1233,56 @@ function createPopup() {
           }
 
           gptResult.textContent += chunk;
-          
-          
+
+
         });
         ttsReady = true;
         showPopup(popup, null, input, { x: mousePosition.x, y: mousePosition.y });
       }
     }
+
+    if (request.text === "analyzeImage") {
+      const mousePosition = request.mousePosition || { x: 0, y: 0 };
+      const popup = document.getElementById("input-focus-popup") || createPopup();
+      const input = popup.querySelector(".popup-input");
+      const gptResult = popup.querySelector("#popup-gpt-result");
+
+      gptResult.textContent = "Analyzing image…";
+      ttsReady = false;
+      showPopup(popup, null, input, { x: mousePosition.x, y: mousePosition.y });
+
+      try {
+        const imageParts = await fetchImageInlineParts(request.imageUrl);
+        gptResult.textContent = "";
+        await fetchFreeGPTResponse(
+          "Describe this image in detail, highlighting subjects, colors, emotions, and potential context.",
+          (chunk) => {
+            if (chunk) {
+              gptResult.textContent += chunk;
+            }
+          },
+          { imageParts }
+        );
+        ttsReady = true;
+      } catch (error) {
+        console.error("Image analysis failed", error);
+        const errorMessage =
+          error?.message?.replace(/^Error:\s*/, "") ||
+          "Unable to analyze this image. Try a different image or enable a Gemini model.";
+        gptResult.textContent = errorMessage;
+      }
+    }
   });
 
   function ToggleInternetButton() {
-    
-      let internetMode = localStorage.getItem("gptinternet");
-
-      if (internetMode === "false" || internetMode === null) {
-        localStorage.setItem("gptinternet", "true")
-        internetButton.classList.add("enabled"); 
-      }
-
-      if (internetMode === "true") {
-        localStorage.setItem("gptinternet", "false")
-        internetButton.classList.remove("enabled");
-      }
+    const internetMode = localStorage.getItem("gptinternet");
+    if (internetMode === "true") {
+      localStorage.setItem("gptinternet", "false");
+      internetButton.classList.remove("enabled");
+    } else {
+      localStorage.setItem("gptinternet", "true");
+      internetButton.classList.add("enabled");
+    }
   }
 
  

--- a/src/manifest.json
+++ b/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "GPT-OTG DEVELOPMENT BUILD",
-  "version": "0.5.7",
+  "version": "0.6.8",
   "description": "THIS EXTENSION IS FOR BETA TESTING",
   "permissions": [
     "activeTab",
@@ -9,6 +9,13 @@
     "webNavigation",
     "storage",
     "tabs"
+  ],
+  "host_permissions": [
+    "https://api.openai.com/*",
+    "https://generativelanguage.googleapis.com/*",
+    "https://api.anthropic.com/*",
+    "https://api.deepseek.com/*",
+    "https://gpt-otg-websearch-api.vercel.app/*"
   ],
   "action": {
     "default_title": "Open"

--- a/src/options.css
+++ b/src/options.css
@@ -1,129 +1,281 @@
-/* options.css */
+:root {
+  color-scheme: light dark;
+  --surface: rgba(255, 255, 255, 0.86);
+  --surface-dark: rgba(23, 23, 26, 0.7);
+  --border: rgba(15, 23, 42, 0.08);
+  --border-dark: rgba(226, 232, 240, 0.1);
+  --text: #0f172a;
+  --text-muted: #64748b;
+  --primary: #2563eb;
+  --primary-hover: #1d4ed8;
+  --background: linear-gradient(135deg, #f8fafc 0%, #eef2ff 100%);
+  --background-dark: radial-gradient(circle at top, #111827 0%, #020617 100%);
+  font-family: "Inter", "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, sans-serif;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: rgba(17, 25, 40, 0.8);
+    --border: rgba(255, 255, 255, 0.06);
+    --text: #e2e8f0;
+    --text-muted: #94a3b8;
+    --background: var(--background-dark);
+  }
+}
+
+* {
+  box-sizing: border-box;
+}
 
 body {
-  font-family: Arial, sans-serif;
   margin: 0;
-  padding: 0;
-  background-color: #f8f8f8;
+  min-height: 100vh;
+  background: var(--background);
+  display: flex;
+  justify-content: center;
+  padding: clamp(1.5rem, 2vw, 3rem);
+  color: var(--text);
 }
 
-.wrapper {
-  max-width: 600px;
-  margin: 40px auto;
-  padding: 20px;
-  background-color: #fff;
-  box-shadow: 0 0 5px rgba(0, 0, 0, 0.1);
-  border-radius: 5px;
+.options {
+  width: min(960px, 100%);
   display: flex;
   flex-direction: column;
+  gap: clamp(1.5rem, 2vw, 2.5rem);
+}
+
+.options__header {
+  display: flex;
+  gap: 1.5rem;
   align-items: center;
+  padding: clamp(1.5rem, 2vw, 2.5rem);
+  border-radius: 24px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.12);
 }
 
-.setting-header{
-    display: flex;
-    flex-direction: row;
-    align-items: center;
-    justify-content: space-between;
-}
-.setting {
-  text-align: center;
-  margin-top: 20px;
+.options__logo {
+  border-radius: 16px;
+  box-shadow: 0 10px 30px rgba(37, 99, 235, 0.2);
 }
 
-.setting img {
-  margin-bottom: 20px;
+.options__title {
+  margin: 0 0 0.25rem;
+  font-size: clamp(1.8rem, 2.4vw, 2.4rem);
+  font-weight: 700;
 }
 
-.setting h1 {
-  font-size: 24px;
-  margin-bottom: 20px;
+.options__subtitle {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: 0.95rem;
 }
 
-.label-on-left {
-    margin-top: 10px;
-    width: 100%;
+.options__form {
+  display: grid;
+  gap: clamp(1.25rem, 2vw, 2rem);
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 24px;
+  padding: clamp(1.5rem, 2vw, 2.25rem);
+  border: 1px solid var(--border);
+  backdrop-filter: blur(16px);
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.25);
+}
+
+.card__title {
+  margin: 0 0 1.25rem;
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-bottom: 1.5rem;
+}
+
+.field:last-child {
+  margin-bottom: 0;
+}
+
+#keyFields {
+  margin-bottom: 0;
+  gap: 0;
+}
+
+#keyFields .field {
+  margin-bottom: 1rem;
+}
+
+#keyFields .field:last-child {
+  margin-bottom: 0;
+}
+
+.field__label {
+  font-weight: 600;
+  font-size: 0.95rem;
+}
+
+.field__input {
+  border: 1px solid var(--border);
+  border-radius: 14px;
+  padding: 0.85rem 1rem;
+  font: inherit;
+  background: rgba(255, 255, 255, 0.6);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+@media (prefers-color-scheme: dark) {
+  .field__input {
+    background: rgba(15, 23, 42, 0.6);
   }
-  
-  .label-on-left label {
-    flex: 0.5;
-    font-size: 14px;
-    font-weight: bold;
-    text-align: left;
-    margin-right: 10px;
-  }
-  
-  .label-on-left input[type="checkbox"],
-  .label-on-left select,
-  .label-on-left textarea {
-    flex: 1.5;
-  }
-  
-
-#model,
-#ai {
-  margin-left: 10px;
 }
 
-textarea {
-  width: 100%;
-  padding: 10px;
-  margin-top: 10px;
+.field__input:focus {
+  border-color: rgba(37, 99, 235, 0.6);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
+  outline: none;
+}
+
+.field__input--textarea {
   resize: vertical;
+  min-height: 140px;
+  line-height: 1.5;
 }
 
-button {
-  margin-top: 20px;
-  padding: 10px 20px;
-  font-size: 16px;
-  background-color: #4b8df8;
-  color: #fff;
-  border: none;
-  border-radius: 3px;
+.field__hint {
+  margin: 0;
+  font-size: 0.82rem;
+  color: var(--text-muted);
 }
 
-.warning{
-  color: red;
-  font-size: 12px;
-  margin-top: 10px;
-  margin-bottom: 10px;
+.toggle {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  padding: 0.65rem 0;
+  border-bottom: 1px solid rgba(15, 23, 42, 0.06);
 }
 
-button:disabled {
-  background-color: #5f5f5f;
-  color: #fff;
-  cursor: not-allowed;
+.toggle:last-child {
+  border-bottom: none;
 }
 
-button:disabled:hover {
-  background-color: #5f5f5f;
-  color: #fff;
-  cursor: not-allowed;
+.toggle__input {
+  appearance: none;
+  width: 44px;
+  height: 24px;
+  border-radius: 999px;
+  background: rgba(148, 163, 184, 0.5);
+  position: relative;
+  transition: background 0.2s ease;
 }
 
-#contentWrapper {
-    display: flex;
-    flex-direction: column;
-    align-items: flex-start;
-    justify-content: flex-start;
-    width: 100%;
+.toggle__input::after {
+  content: "";
+  position: absolute;
+  top: 3px;
+  left: 4px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 4px 10px rgba(15, 23, 42, 0.15);
+  transition: transform 0.2s ease;
+}
+
+.toggle__input:checked {
+  background: rgba(37, 99, 235, 0.6);
+}
+
+.toggle__input:checked::after {
+  transform: translateX(18px);
+}
+
+.toggle__label {
+  font-weight: 500;
+}
+
+.options__footer {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  align-items: flex-start;
+}
+
+@media (min-width: 720px) {
+  .options__footer {
+    flex-direction: row;
+    justify-content: space-between;
+    align-items: center;
   }
-
-button:hover {
-  background-color: #357ae8;
 }
 
-#popup-gpt-result{
-  height: 500px;
-  width: 49%;
-  font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
-  font-size: 14px; 
-  padding: 2px;
-float:left;
+.options__status {
+  min-height: 1.25rem;
+  font-size: 0.85rem;
+  color: var(--text-muted);
 }
-.result-html{
-  min-height: 500px;
-  width: 49%;
-padding: 2px;
-border: 1px solid #ccc;
-float:right;
+
+.options__status[data-type="success"] {
+  color: #15803d;
+}
+
+.options__status[data-type="error"] {
+  color: #b91c1c;
+}
+
+.options__actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.btn {
+  border: none;
+  border-radius: 999px;
+  padding: 0.75rem 1.75rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  cursor: pointer;
+  transition: transform 0.15s ease, box-shadow 0.2s ease, background 0.2s ease;
+  color: #fff;
+  background: linear-gradient(135deg, var(--primary), #4f46e5);
+  box-shadow: 0 15px 30px -18px rgba(37, 99, 235, 0.85);
+}
+
+.btn:hover {
+  transform: translateY(-1px);
+  background: linear-gradient(135deg, var(--primary-hover), #4338ca);
+}
+
+.btn:active {
+  transform: translateY(0);
+}
+
+.btn--secondary {
+  background: rgba(148, 163, 184, 0.2);
+  color: var(--text);
+  box-shadow: none;
+}
+
+.btn--secondary:hover {
+  background: rgba(148, 163, 184, 0.3);
+}
+
+.btn:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+  transform: none;
+  box-shadow: none;
+}
+
+.hidden {
+  display: none !important;
 }

--- a/src/options.html
+++ b/src/options.html
@@ -1,70 +1,145 @@
-<html>
+<!DOCTYPE html>
+<html lang="en">
   <head>
-    <title>Setting</title>
-    <link rel="icon" href="icon.png" type="image/png" sizes="16x16" />
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>GPT-OTG Settings</title>
+    <link rel="icon" href="icon.png" type="image/png" sizes="32x32" />
+    <link rel="stylesheet" href="options.css" />
   </head>
-  <link rel="stylesheet" href="options.css" />
   <body>
-    <div class="wrapper">
-      <div class="setting">
-        <div class="setting-header">
-        <img src="icon.png" alt="icon" width="100" height="100" />
-        <h1>GPT-OTG Options</h1>
+    <main class="options">
+      <header class="options__header">
+        <img class="options__logo" src="icon.png" alt="GPT-OTG" width="72" height="72" />
+        <div>
+          <h1 class="options__title">GPT-OTG Preferences</h1>
+          <p class="options__subtitle">Tune the assistant, choose a model, and manage integrations.</p>
         </div>
-        </div>
-        <div id="contentWrapper">
-            <div class="label-on-left">
-              <label for="model">Select AI Model</label>
-              <select id="model">
-                <option selected value="gpt-3.5-turbo">ChatGPT 3.5 Turbo</option>
-                <option value="gpt-4">ChatGPT 4</option>
-                <option value="bing">Bing Chat</option>
-                <option value="bard">Google Bard</option>
-                <option value="custom">Add your API</option>
-              </select>
-            </div>
+      </header>
 
+      <form id="settingsForm" class="options__form">
+        <section class="card">
+          <h2 class="card__title">AI Model</h2>
+          <div class="field">
+            <label class="field__label" for="model">Provider &amp; model</label>
+            <select class="field__input" id="model" name="model">
+              <optgroup label="OpenAI">
+                <option value="openai-gpt-4o-mini">GPT-4o mini (fast, multimodal)</option>
+                <option value="openai-gpt-4o">GPT-4o (best quality)</option>
+              </optgroup>
+              <optgroup label="Google Gemini">
+                <option value="gemini-1.5-flash">Gemini 1.5 Flash (vision)</option>
+                <option value="gemini-2.0-flash">Gemini 2.0 Flash Experimental</option>
+              </optgroup>
+              <optgroup label="Anthropic">
+                <option value="anthropic-claude-3-5-sonnet">Claude 3.5 Sonnet</option>
+              </optgroup>
+              <optgroup label="DeepSeek">
+                <option value="deepseek-chat">DeepSeek Chat</option>
+                <option value="deepseek-reasoner">DeepSeek Reasoner</option>
+              </optgroup>
+            </select>
+            <p class="field__hint" id="modelHint"></p>
+          </div>
 
-            <div class="label-on-left">
-              <label for="tune">Tune the model</label>
-              <select id="tune">
-                <option value="creative">Creative</option>
-                <option selected value="balance">Balance</option>
-                <option value="precise">Precise</option>
-              </select>
+          <div class="field" id="keyFields">
+            <div class="field hidden" data-provider-key="openai">
+              <label class="field__label" for="openaiApiKey">OpenAI API key</label>
+              <input
+                class="field__input"
+                type="password"
+                id="openaiApiKey"
+                name="openaiApiKey"
+                placeholder="sk-..."
+                autocomplete="off"
+              />
+              <p class="field__hint">Used for GPT-4o models.</p>
             </div>
-    
-            <div class="label-on-left">
-              <label for="aiCommand">Enable command '/ai'</label>
-              <input type="checkbox" id="aiCommand" name="aiCommand" value="aiCommand" />
+            <div class="field hidden" data-provider-key="gemini">
+              <label class="field__label" for="geminiApiKey">Gemini API key</label>
+              <input
+                class="field__input"
+                type="password"
+                id="geminiApiKey"
+                name="geminiApiKey"
+                placeholder="AIza..."
+                autocomplete="off"
+              />
+              <p class="field__hint">Required to access Gemini 1.5 and 2.0 models.</p>
             </div>
+            <div class="field hidden" data-provider-key="anthropic">
+              <label class="field__label" for="anthropicApiKey">Anthropic API key</label>
+              <input
+                class="field__input"
+                type="password"
+                id="anthropicApiKey"
+                name="anthropicApiKey"
+                placeholder="anthropic-..."
+                autocomplete="off"
+              />
+              <p class="field__hint">Used for Claude 3.5 Sonnet.</p>
+            </div>
+            <div class="field hidden" data-provider-key="deepseek">
+              <label class="field__label" for="deepseekApiKey">DeepSeek API key</label>
+              <input
+                class="field__input"
+                type="password"
+                id="deepseekApiKey"
+                name="deepseekApiKey"
+                placeholder="sk-..."
+                autocomplete="off"
+              />
+              <p class="field__hint">Used for DeepSeek Chat/Reasoner.</p>
+            </div>
+          </div>
+        </section>
 
-            <div class="label-on-left">
-              <label for="googleSearch">Enable Google Search Sidebar
+        <section class="card">
+          <h2 class="card__title">Behavior</h2>
+          <div class="field">
+            <label class="field__label" for="tune">Tone preset</label>
+            <select class="field__input" id="tune" name="tune">
+              <option value="creative">Creative</option>
+              <option value="balance">Balanced</option>
+              <option value="precise">Precise</option>
+            </select>
+          </div>
 
-              </label>
-              <input type="checkbox" id="googleSearch" name="googleSearch" value="googleSearch" />
-            </div>
+          <div class="field">
+            <label class="field__label" for="initialPrompt">System prompt</label>
+            <textarea class="field__input field__input--textarea" id="initialPrompt" name="initialPrompt" rows="6"></textarea>
+            <p class="field__hint">Customize how the assistant introduces itself and responds.</p>
+          </div>
+        </section>
 
-            <div class="label-on-left">
-              <label for="youtubeSummary">Enable Youtube Summary Sidebar
+        <section class="card">
+          <h2 class="card__title">Shortcuts &amp; Integrations</h2>
+          <label class="toggle">
+            <input class="toggle__input" type="checkbox" id="aiCommand" name="aiCommand" />
+            <span class="toggle__label">Enable /ai command</span>
+          </label>
 
-              </label>
-              <input type="checkbox" id="youtubeSummary" name="youtubeSummary" value="youtubeSummary" />
-            </div>
-    
-            <div class="label-on-left">
-              <label for="initialPrompt">initial prompt</label>
-              <textarea id="initialPrompt" rows="7"></textarea>
-            </div>
-    
-            </div>
+          <label class="toggle">
+            <input class="toggle__input" type="checkbox" id="googleSearch" name="googleSearch" />
+            <span class="toggle__label">Show Google search sidebar results</span>
+          </label>
 
-        <div class="setting">
-        <button id="save">Save</button>
-        <button id="reset">Reset</button>
-        </div>
-    </div>
+          <label class="toggle">
+            <input class="toggle__input" type="checkbox" id="youtubeSummary" name="youtubeSummary" />
+            <span class="toggle__label">Show YouTube summary button</span>
+          </label>
+        </section>
+
+        <footer class="options__footer">
+          <span class="options__status" id="statusMessage" role="status" aria-live="polite"></span>
+          <div class="options__actions">
+            <button class="btn btn--secondary" type="button" id="reset">Reset</button>
+            <button class="btn" type="button" id="save">Save changes</button>
+          </div>
+        </footer>
+      </form>
+    </main>
+
     <script src="options.js"></script>
   </body>
 </html>

--- a/src/popup.css
+++ b/src/popup.css
@@ -1,236 +1,208 @@
+:root {
+  font-family: "Inter", "Segoe UI", system-ui, sans-serif;
+  color-scheme: light dark;
+}
+
+#input-focus-popup {
+  position: absolute;
+  z-index: 9999;
+  min-width: 340px;
+  max-width: min(520px, 90vw);
+  color: #0f172a;
+  pointer-events: auto;
+}
+
+@media (prefers-color-scheme: dark) {
+  #input-focus-popup {
+    color: #e2e8f0;
+  }
+}
+
 .popup-content {
-  background-color: transparent;
-  padding: 10px;
-  box-sizing: border-box;
-  color: rgb(0, 0, 0);
-  border-radius: 0%;
-  transition: all 0.5s ease-in-out;
-  min-width: fit-content;
+  background: radial-gradient(circle at top left, rgba(255, 255, 255, 0.97), rgba(241, 245, 255, 0.93));
+  border-radius: 20px;
+  padding: 18px 20px 16px;
+  box-shadow: 0 20px 40px -24px rgba(15, 23, 42, 0.4);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  backdrop-filter: blur(12px);
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
 }
 
-.popup-content:hover{
-    opacity: 1;
+.popup-content:hover {
+  transform: translateY(-2px);
+  box-shadow: 0 30px 55px -26px rgba(15, 23, 42, 0.45);
 }
 
-.input-focus-popup:hover{
-  opacity: 1;
-}
-
-
-#popup-gpt-result {
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-  background-color: white;
-  border: none;
-  color: black;
-  max-width: 500px;
-}
-
-.popup-close-button {
-  position: absolute;
-  top: 5px;
-  right: 10px;
-  font-size: 20px;
-  font-weight: bold;
-  color: #666;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  outline: none;
-}
-
-.popup-internet-button {
-  position: absolute;
-  top: 10px;
-  right: 65px;
-  font-size: 10px;
-  font-weight: bold;
-  color: #666;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  outline: none;
-}
-
-.enabled {
-  color: #020fc5;
-}
-
-.enabled:hover {
-  color: #010a8e;
-}
-
-.popup-tts-button {
-  position: absolute;
-  top: 10px;
-  right: 40px;
-  font-size: 10px;
-  font-weight: bold;
-  color: #666;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  outline: none;
-}
-
-.popup-gear-button {
-  position: absolute;
-  top: 4px;
-  right: 25px;
-  font-size: 20px;
-  font-weight: bold;
-  color: #666;
-  background-color: transparent;
-  border: none;
-  cursor: pointer;
-  outline: none;
-}
-
-.popup-close-button:hover {
-  color: #333;
-}
-
-.popup-gear-button:hover {
-  color: #333;
-}
-
-.popup-tts-button:hover {
-  color: #333;
-}
-
-.popup-internet-button:hover {
-  color: #020fc5
-}
-
-.popup-wrapper {
-  min-width: 300px;
-}
-
-.popup-input {
-  background-color: white;
-  border: none;
-  white-space: pre-wrap;
-  overflow-wrap: break-word;
-  width: 100% !important;
-  min-width: 100% !important;
-  color: black;
-}
-
-input:focus,
-input.form-control:focus {
-  outline: none !important;
-  outline-width: 0 !important;
-  box-shadow: none;
-  -moz-box-shadow: none;
-  -webkit-box-shadow: none;
+@media (prefers-color-scheme: dark) {
+  .popup-content {
+    background: linear-gradient(135deg, rgba(17, 24, 39, 0.95), rgba(15, 23, 42, 0.9));
+    border: 1px solid rgba(255, 255, 255, 0.08);
+    box-shadow: 0 25px 50px -20px rgba(0, 0, 0, 0.55);
+  }
 }
 
 .popup-wrapper {
   display: flex;
   flex-direction: column;
-  align-items: stretch;
-  background-color: white;
-  border: 1px solid #ccc;
-  border-radius: 4px;
-  padding: 10px;
-  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.1);
-}
-.popup-input {
-  resize: both;
-  min-height: 30px;
-  max-height: 100px;
-  resize: both;
-  margin-bottom: 10px;
-  color: black;
+  gap: 12px;
 }
 
-#popup-gpt-result {
-  border-top: 3px dotted #bbb;
-  resize: none;
-  min-height: 100px;
-  max-height: 1000px;
-  overflow-y: auto;
-  color: black;
-  line-height: 1.5;
+.popup-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.popup-title {
+  margin: 0;
+  font-weight: 600;
+  font-size: 1rem;
+  color: inherit;
+}
+
+.popup-toolbar {
+  display: inline-flex;
+  gap: 6px;
+  align-items: center;
+}
+
+.popup-icon-button {
+  border: none;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+  padding: 6px 10px;
+  font-size: 0.72rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.2s ease;
+}
+
+.popup-close-button {
+  font-size: 0.9rem;
+  line-height: 1;
+}
+
+.popup-icon-button:hover,
+.popup-icon-button.enabled {
+  background: rgba(37, 99, 235, 0.2);
+  color: #1d4ed8;
+  transform: translateY(-1px);
+}
+
+@media (prefers-color-scheme: dark) {
+  .popup-icon-button {
+    background: rgba(148, 163, 184, 0.16);
+  }
+
+  .popup-icon-button:hover,
+  .popup-icon-button.enabled {
+    background: rgba(96, 165, 250, 0.24);
+    color: #bfdbfe;
+  }
 }
 
 .popup-input-wrapper {
-  background-color: white;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
-
-.half-scroll::-webkit-scrollbar-thumb {
-  background-color: #ccc;
-  border-radius: 5px;
+.popup-input {
+  width: 100%;
+  border: 1px solid rgba(15, 23, 42, 0.12);
+  border-radius: 14px;
+  padding: 10px 14px;
+  font: inherit;
+  background: rgba(255, 255, 255, 0.75);
+  color: inherit;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
-.half-scroll::-webkit-scrollbar {
-  width: 8px;
-}
-
-.half-scroll::-webkit-scrollbar-track {
-  background-color: #f1f1f1;
-}
-
-.half-scroll:focus {
-  /* set the scroll position to show the half part of the remaining text when the textarea is focused */
-  scroll-behavior: smooth;
-  scroll-margin-block: 50%; /* set the margin block to 50% to show the half part of the remaining text */
-}
-
-.textarea-container {
-  position: relative;
-}
-
-.suggestion-button {
-  background-color: transparent;
-  border: none;
-  color: #666;
-  font-size: 12px;
-  font-weight: bold;
-  cursor: pointer;
+.popup-input:focus {
   outline: none;
-  padding: 0;
-  margin-top: 5px;
+  border-color: rgba(37, 99, 235, 0.5);
+  box-shadow: 0 0 0 4px rgba(37, 99, 235, 0.12);
 }
 
-.suggestion-button:hover {
-  color: #333;
+@media (prefers-color-scheme: dark) {
+  .popup-input {
+    background: rgba(17, 24, 39, 0.7);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+}
+
+#popup-gpt-result {
+  white-space: pre-wrap;
+  word-break: break-word;
+  border-radius: 16px;
+  background: rgba(15, 23, 42, 0.03);
+  border: 1px solid rgba(15, 23, 42, 0.06);
+  padding: 14px 16px;
+  min-height: 120px;
+  max-height: 420px;
+  overflow-y: auto;
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+@media (prefers-color-scheme: dark) {
+  #popup-gpt-result {
+    background: rgba(148, 163, 184, 0.08);
+    border: 1px solid rgba(148, 163, 184, 0.2);
+  }
+}
+
+#popup-gpt-result:focus {
+  outline: none;
+  box-shadow: inset 0 0 0 1px rgba(37, 99, 235, 0.4);
 }
 
 .popup-suggestion-wrapper {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: flex-start;
-  margin-bottom: 10px;
-  margin-top: 5px;
-  border-top: 3px dotted #bbb;
-}
-
-
-
-
-.yt-button {
-  color:var(--yt-spec-text-primary);
-  background-color: var(--yt-spec-badge-chip-background);
-  padding: 10px 16px;
-  border: none;
-  border-radius: 30px;
-  text-transform: capitalize;
-  font-weight: 500;
-  margin-right: 5px;
-  outline: none;
-  cursor: pointer;
-  transition: background-color 0.2s ease;
-  box-shadow: 0 1px 2px rgba(0,0,0,0.15);
-}
-
-.hidden {
   display: none;
+  flex-wrap: wrap;
+  gap: 6px;
 }
 
-.yt-button:hover {
-  background-color: var(--yt-spec-mono-tonal-hover);
+.popup-suggestion-wrapper.has-suggestions {
+  display: flex;
 }
 
+.suggestion-button {
+  align-self: flex-start;
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(37, 99, 235, 0.2);
+  background: rgba(37, 99, 235, 0.08);
+  color: #1d4ed8;
+  font-size: 0.78rem;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, background 0.2s ease, border-color 0.2s ease;
+}
+
+.suggestion-button:hover {
+  transform: translateY(-1px);
+  background: rgba(37, 99, 235, 0.12);
+  border-color: rgba(37, 99, 235, 0.4);
+}
+
+@media (prefers-color-scheme: dark) {
+  .suggestion-button {
+    background: rgba(59, 130, 246, 0.12);
+    border-color: rgba(96, 165, 250, 0.2);
+    color: #93c5fd;
+  }
+
+  .suggestion-button:hover {
+    background: rgba(59, 130, 246, 0.18);
+    border-color: rgba(96, 165, 250, 0.4);
+  }
+}
+
+textarea,
+input,
+button {
+  font-family: inherit;
+}


### PR DESCRIPTION
## Summary
- add first-party OpenAI, Gemini, Anthropic, and DeepSeek models with dedicated API key storage, follow-up generation, and required host permissions
- refresh the options and background defaults so every provider can be configured from the UI with per-provider key inputs
- modernize the assistant popup, fix suggestion parsing, and make follow-ups clickable for quick re-prompts

## Testing
- CI=true npm run build *(fails: missing path-scurry module in the vendored node_modules directory)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6912f28b38788328bd0bc9a1f7b01671)